### PR TITLE
Fix tray icon size on GNOME

### DIFF
--- a/src/main/java/com/group_finity/mascot/Main.java
+++ b/src/main/java/com/group_finity/mascot/Main.java
@@ -431,6 +431,7 @@ public class Main {
         try {
             // Create the tray icon
             final TrayIcon icon = new TrayIcon(image, languageBundle.getString("ShimejiEE"));
+            icon.setImageAutoSize(true);
 
             // attach menu
             icon.addMouseListener(new MouseListener() {


### PR DESCRIPTION
Tested on NixOS GNOME, with 100% display scaling and 1.15x font scaling.

Before:
![图片](https://github.com/user-attachments/assets/f4a051f0-5869-4e61-a635-fa5782dd5c5d)

After:
![图片](https://github.com/user-attachments/assets/d43ab697-8ddd-41bb-9478-db19d628a396)
