### PR TITLE
Further reduce boilerplate with Lombok

### DIFF
--- a/conf/theme.properties
+++ b/conf/theme.properties
@@ -1,3 +1,8 @@
+#Wed May 14 16:20:14 ADT 2025
+nimrodlf.b=\#000000
+nimrodlf.font=SansSerif-PLAIN-12
+nimrodlf.frameOpacity=255
+nimrodlf.menuOpacity=255
 nimrodlf.p1=\#1EA6EB
 nimrodlf.p2=\#28B0F5
 nimrodlf.p3=\#32BAFF
@@ -5,7 +10,3 @@ nimrodlf.s1=\#BCBCBE
 nimrodlf.s2=\#C6C6C8
 nimrodlf.s3=\#D0D0D2
 nimrodlf.w=\#FFFFFF
-nimrodlf.b=\#000000
-nimrodlf.menuOpacity=255
-nimrodlf.frameOpacity=255
-nimrodlf.font=SansSerif-PLAIN-12

--- a/src/main/java/com/group_finity/mascot/Mascot.java
+++ b/src/main/java/com/group_finity/mascot/Mascot.java
@@ -12,6 +12,8 @@ import com.group_finity.mascot.image.MascotImage;
 import com.group_finity.mascot.image.TranslucentWindow;
 import com.group_finity.mascot.menu.MenuScroller;
 import com.group_finity.mascot.sound.Sounds;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.sound.sampled.Clip;
 import javax.swing.*;
@@ -62,69 +64,70 @@ public class Mascot {
      */
     private final int id;
 
-    private String imageSet;
+    @Getter @Setter private String imageSet;
+
     /**
      * The window that displays the {@code Mascot}.
      */
-    private final TranslucentWindow window = NativeFactory.getInstance().newTransparentWindow();
+    @Getter private final TranslucentWindow window = NativeFactory.getInstance().newTransparentWindow();
 
     /**
      * The {@link Manager} that manages this {@code Mascot}.
      */
-    private Manager manager = null;
+    @Getter @Setter private Manager manager = null;
 
     /**
      * The {@code Mascot}'s ground coordinates.
      * For example, its feet or its hands when hanging.
      */
-    private Point anchor = new Point(0, 0);
+    @Getter @Setter private Point anchor = new Point(0, 0);
 
     /**
      * The image to display.
      */
-    private MascotImage image = null;
+    @Getter @Setter private MascotImage image = null;
 
     /**
      * Whether the {@code Mascot} is facing right.
      * The original image is treated as facing left, so setting this to {@code true} will cause it to be reversed.
      */
-    private boolean lookRight = false;
+    @Getter @Setter private boolean lookRight = false;
 
     /**
      * An object that represents the long-term behavior of this {@code Mascot}.
      */
-    private Behavior behavior = null;
+    @Getter private Behavior behavior = null;
 
     /**
      * Time that increases every tick of the timer.
      */
-    private int time = 0;
+    @Getter @Setter private int time = 0;
 
     /**
      * Whether the animation is running.
      */
-    private boolean animating = true;
+    @Getter @Setter private boolean animating = true;
 
-    private boolean paused = false;
+    @Getter @Setter private boolean paused = false;
 
     /**
      * Set by behaviours when the {@code Mascot} is being dragged by the mouse cursor,
      * as opposed to hotspots or the like.
      */
-    private boolean dragging = false;
+    @Getter @Setter private boolean dragging = false;
 
     /**
      * Mascot display environment.
      */
-    private MascotEnvironment environment = new MascotEnvironment(this);
+    @Getter private MascotEnvironment environment = new MascotEnvironment(this);
 
-    private String sound = null;
+    @Getter @Setter private String sound = null;
 
     protected DebugWindow debugWindow = null;
 
-    private final List<String> affordances = new ArrayList<>(5);
+    @Getter private final List<String> affordances = new ArrayList<>(5);
 
-    private final List<Hotspot> hotspots = new ArrayList<>(5);
+    @Getter private final List<Hotspot> hotspots = new ArrayList<>(5);
 
     /**
      * Set by behaviours when the user has triggered a hotspot on this {@code Mascot},
@@ -524,38 +527,6 @@ public class Mascot {
         getWindow().asComponent().setCursor(Cursor.getPredefinedCursor(useHand ? Cursor.HAND_CURSOR : Cursor.DEFAULT_CURSOR));
     }
 
-    public Manager getManager() {
-        return manager;
-    }
-
-    public void setManager(final Manager manager) {
-        this.manager = manager;
-    }
-
-    public Point getAnchor() {
-        return anchor;
-    }
-
-    public void setAnchor(Point anchor) {
-        this.anchor = anchor;
-    }
-
-    public MascotImage getImage() {
-        return image;
-    }
-
-    public void setImage(final MascotImage image) {
-        this.image = image;
-    }
-
-    public boolean isLookRight() {
-        return lookRight;
-    }
-
-    public void setLookRight(final boolean lookRight) {
-        this.lookRight = lookRight;
-    }
-
     public Rectangle getBounds() {
         if (getImage() != null) {
             // Find the window area from the ground coordinates and image center coordinates. The center has already been adjusted for scaling.
@@ -569,18 +540,6 @@ public class Mascot {
         }
     }
 
-    public int getTime() {
-        return time;
-    }
-
-    private void setTime(final int time) {
-        this.time = time;
-    }
-
-    public Behavior getBehavior() {
-        return behavior;
-    }
-
     public void setBehavior(final Behavior behavior) throws CantBeAliveException {
         this.behavior = behavior;
         this.behavior.init(this);
@@ -592,62 +551,6 @@ public class Mascot {
 
     public int getTotalCount() {
         return manager != null ? getManager().getCount() : 0;
-    }
-
-    private boolean isAnimating() {
-        return animating && !paused;
-    }
-
-    private void setAnimating(final boolean animating) {
-        this.animating = animating;
-    }
-
-    private TranslucentWindow getWindow() {
-        return window;
-    }
-
-    public MascotEnvironment getEnvironment() {
-        return environment;
-    }
-
-    public List<String> getAffordances() {
-        return affordances;
-    }
-
-    public List<Hotspot> getHotspots() {
-        return hotspots;
-    }
-
-    public void setImageSet(final String set) {
-        imageSet = set;
-    }
-
-    public String getImageSet() {
-        return imageSet;
-    }
-
-    public String getSound() {
-        return sound;
-    }
-
-    public void setSound(final String name) {
-        sound = name;
-    }
-
-    public boolean isPaused() {
-        return paused;
-    }
-
-    public void setPaused(final boolean paused) {
-        this.paused = paused;
-    }
-
-    public boolean isDragging() {
-        return dragging;
-    }
-
-    public void setDragging(final boolean isDragging) {
-        dragging = isDragging;
     }
 
     public boolean isHotspotClicked() {

--- a/src/main/java/com/group_finity/mascot/action/ActionBase.java
+++ b/src/main/java/com/group_finity/mascot/action/ActionBase.java
@@ -8,6 +8,8 @@ import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.hotspot.Hotspot;
 import com.group_finity.mascot.script.Variable;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 import java.util.ResourceBundle;
@@ -38,15 +40,15 @@ public abstract class ActionBase implements Action {
 
     private static final String DEFAULT_AFFORDANCE = "";
 
-    private Mascot mascot;
+    @Getter @Setter private Mascot mascot;
 
     private int startTime;
 
-    private List<Animation> animations;
+    @Getter private List<Animation> animations;
 
-    private VariableMap variables;
+    @Getter private VariableMap variables;
 
-    private ResourceBundle schema;
+    @Getter private ResourceBundle schema;
 
     public ActionBase(ResourceBundle schema, final List<Animation> animations, final VariableMap context) {
         this.schema = schema;
@@ -117,10 +119,6 @@ public abstract class ActionBase implements Action {
         }
     }
 
-    protected List<Animation> getAnimations() {
-        return animations;
-    }
-
     protected abstract void tick() throws LostGroundException, VariableException;
 
     @Override
@@ -165,14 +163,6 @@ public abstract class ActionBase implements Action {
         return eval(schema.getString(PARAMETER_AFFORDANCE), String.class, DEFAULT_AFFORDANCE);
     }
 
-    private void setMascot(final Mascot mascot) {
-        this.mascot = mascot;
-    }
-
-    protected Mascot getMascot() {
-        return mascot;
-    }
-
     protected int getTime() {
         return getMascot().getTime() - startTime;
     }
@@ -195,10 +185,6 @@ public abstract class ActionBase implements Action {
         return null;
     }
 
-    protected VariableMap getVariables() {
-        return variables;
-    }
-
     protected void putVariable(final String key, final Object value) {
         synchronized (getVariables()) {
             getVariables().put(key, value);
@@ -218,9 +204,5 @@ public abstract class ActionBase implements Action {
 
     protected MascotEnvironment getEnvironment() {
         return getMascot().getEnvironment();
-    }
-
-    protected ResourceBundle getSchema() {
-        return schema;
     }
 }

--- a/src/main/java/com/group_finity/mascot/action/BorderedAction.java
+++ b/src/main/java/com/group_finity/mascot/action/BorderedAction.java
@@ -6,6 +6,8 @@ import com.group_finity.mascot.environment.Border;
 import com.group_finity.mascot.exception.LostGroundException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 import java.util.ResourceBundle;
@@ -31,7 +33,7 @@ public abstract class BorderedAction extends ActionBase {
 
     public static final String BORDERTYPE_FLOOR = "Floor";
 
-    private Border border;
+    @Getter @Setter private Border border;
 
     public BorderedAction(ResourceBundle schema, final List<Animation> animations, final VariableMap context) {
         super(schema, animations, context);
@@ -62,14 +64,6 @@ public abstract class BorderedAction extends ActionBase {
 
     private String getBorderType() throws VariableException {
         return eval(getSchema().getString(PARAMETER_BORDERTYPE), String.class, DEFAULT_BORDERTYPE);
-    }
-
-    private void setBorder(final Border border) {
-        this.border = border;
-    }
-
-    protected Border getBorder() {
-        return border;
     }
 
 }

--- a/src/main/java/com/group_finity/mascot/action/ComplexAction.java
+++ b/src/main/java/com/group_finity/mascot/action/ComplexAction.java
@@ -4,6 +4,7 @@ import com.group_finity.mascot.Mascot;
 import com.group_finity.mascot.exception.LostGroundException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.ResourceBundle;
@@ -19,9 +20,9 @@ public abstract class ComplexAction extends ActionBase {
 
     private static final Logger log = Logger.getLogger(ComplexAction.class.getName());
 
-    private final Action[] actions;
+    @Getter private final Action[] actions;
 
-    private int currentAction;
+    @Getter private int currentAction;
 
     public ComplexAction(ResourceBundle schema, final VariableMap context, final Action... actions) {
         super(schema, new ArrayList<>(), context);
@@ -83,14 +84,6 @@ public abstract class ComplexAction extends ActionBase {
                 getAction().init(getMascot());
             }
         }
-    }
-
-    protected int getCurrentAction() {
-        return currentAction;
-    }
-
-    protected Action[] getActions() {
-        return actions;
     }
 
     protected Action getAction() {

--- a/src/main/java/com/group_finity/mascot/action/ComplexMove.java
+++ b/src/main/java/com/group_finity/mascot/action/ComplexMove.java
@@ -8,6 +8,7 @@ import com.group_finity.mascot.exception.CantBeAliveException;
 import com.group_finity.mascot.exception.LostGroundException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
 
 import java.awt.*;
 import java.lang.ref.WeakReference;
@@ -51,7 +52,7 @@ public class ComplexMove extends BorderedAction {
 
     private WeakReference<Mascot> target;
 
-    private boolean turning = false;
+    @Getter private boolean turning = false;
 
     private Boolean hasTurning = null;
 
@@ -218,10 +219,6 @@ public class ComplexMove extends BorderedAction {
             }
         }
         return hasTurning;
-    }
-
-    protected boolean isTurning() {
-        return turning;
     }
 
     private String getCharacteristics() throws VariableException {

--- a/src/main/java/com/group_finity/mascot/action/Dragged.java
+++ b/src/main/java/com/group_finity/mascot/action/Dragged.java
@@ -6,6 +6,8 @@ import com.group_finity.mascot.animation.Animation;
 import com.group_finity.mascot.environment.Location;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.awt.*;
 import java.util.List;
@@ -33,11 +35,11 @@ public class Dragged extends ActionBase {
 
     private static final int DEFAULT_OFFSETY = 120;
 
-    private double footX;
+    @Getter @Setter private double footX;
 
-    private double footDx;
+    @Getter @Setter private double footDx;
 
-    private int timeToRegist;
+    @Getter @Setter private int timeToRegist;
 
     private double scaling;
 
@@ -97,30 +99,6 @@ public class Dragged extends ActionBase {
             // action does not support hotspots
             getMascot().getHotspots().clear();
         }
-    }
-
-    public void setTimeToRegist(final int timeToRegist) {
-        this.timeToRegist = timeToRegist;
-    }
-
-    private int getTimeToRegist() {
-        return timeToRegist;
-    }
-
-    private void setFootX(final double footX) {
-        this.footX = footX;
-    }
-
-    private double getFootX() {
-        return footX;
-    }
-
-    private void setFootDx(final double footDx) {
-        this.footDx = footDx;
-    }
-
-    private double getFootDx() {
-        return footDx;
     }
 
     private int getOffsetX() throws VariableException {

--- a/src/main/java/com/group_finity/mascot/action/Fall.java
+++ b/src/main/java/com/group_finity/mascot/action/Fall.java
@@ -6,6 +6,8 @@ import com.group_finity.mascot.animation.Animation;
 import com.group_finity.mascot.exception.LostGroundException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.awt.*;
 import java.util.List;
@@ -46,13 +48,13 @@ public class Fall extends ActionBase {
 
     public static final String VARIABLE_VELOCITYY = "VelocityY";
 
-    private double velocityX;
+    @Getter @Setter private double velocityX;
 
-    private double velocityY;
+    @Getter @Setter private double velocityY;
 
-    private double modX;
+    @Getter @Setter private double modX;
 
-    private double modY;
+    @Getter @Setter private double modY;
 
     protected double scaling;
 
@@ -164,37 +166,4 @@ public class Fall extends ActionBase {
     private double getResistanceY() throws VariableException {
         return eval(getSchema().getString(PARAMETER_RESISTANCEY), Number.class, DEFAULT_RESISTANCEY).doubleValue();
     }
-
-    private void setVelocityY(final double velocityY) {
-        this.velocityY = velocityY;
-    }
-
-    private double getVelocityY() {
-        return velocityY;
-    }
-
-    private void setVelocityX(final double velocityX) {
-        this.velocityX = velocityX;
-    }
-
-    private double getVelocityX() {
-        return velocityX;
-    }
-
-    private void setModX(final double modX) {
-        this.modX = modX;
-    }
-
-    private double getModX() {
-        return modX;
-    }
-
-    private void setModY(final double modY) {
-        this.modY = modY;
-    }
-
-    private double getModY() {
-        return modY;
-    }
-
 }

--- a/src/main/java/com/group_finity/mascot/action/Move.java
+++ b/src/main/java/com/group_finity/mascot/action/Move.java
@@ -4,6 +4,7 @@ import com.group_finity.mascot.animation.Animation;
 import com.group_finity.mascot.exception.LostGroundException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
 
 import java.awt.*;
 import java.util.List;
@@ -28,7 +29,7 @@ public class Move extends BorderedAction {
 
     private static final int DEFAULT_TARGETY = Integer.MAX_VALUE;
 
-    protected boolean turning = false;
+    @Getter protected boolean turning = false;
 
     private Boolean hasTurning = null;
 
@@ -122,10 +123,6 @@ public class Move extends BorderedAction {
             }
         }
         return hasTurning;
-    }
-
-    protected boolean isTurning() {
-        return turning;
     }
 
     private int getTargetX() throws VariableException {

--- a/src/main/java/com/group_finity/mascot/action/ScanInteract.java
+++ b/src/main/java/com/group_finity/mascot/action/ScanInteract.java
@@ -8,6 +8,7 @@ import com.group_finity.mascot.exception.CantBeAliveException;
 import com.group_finity.mascot.exception.LostGroundException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
@@ -36,7 +37,7 @@ public class ScanInteract extends BorderedAction {
 
     private WeakReference<Mascot> target;
 
-    private boolean turning = false;
+    @Getter private boolean turning = false;
 
     private Boolean hasTurning = null;
 
@@ -140,10 +141,6 @@ public class ScanInteract extends BorderedAction {
             }
         }
         return hasTurning;
-    }
-
-    protected boolean isTurning() {
-        return turning;
     }
 
     private String getBehavior() throws VariableException {

--- a/src/main/java/com/group_finity/mascot/action/ScanMove.java
+++ b/src/main/java/com/group_finity/mascot/action/ScanMove.java
@@ -8,6 +8,7 @@ import com.group_finity.mascot.exception.CantBeAliveException;
 import com.group_finity.mascot.exception.LostGroundException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
 
 import java.awt.*;
 import java.lang.ref.WeakReference;
@@ -37,7 +38,7 @@ public class ScanMove extends BorderedAction {
 
     private WeakReference<Mascot> target;
 
-    private boolean turning = false;
+    @Getter private boolean turning = false;
 
     private Boolean hasTurning = null;
 
@@ -153,10 +154,6 @@ public class ScanMove extends BorderedAction {
             }
         }
         return hasTurning;
-    }
-
-    protected boolean isTurning() {
-        return turning;
     }
 
     private String getBehavior() throws VariableException {

--- a/src/main/java/com/group_finity/mascot/animation/Animation.java
+++ b/src/main/java/com/group_finity/mascot/animation/Animation.java
@@ -5,6 +5,7 @@ import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.hotspot.Hotspot;
 import com.group_finity.mascot.script.Variable;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
 
 import java.util.Arrays;
 
@@ -15,8 +16,8 @@ import java.util.Arrays;
 public class Animation {
     private Variable condition;
     private final Pose[] poses;
-    private final Hotspot[] hotspots;
-    private boolean turn;
+    @Getter private final Hotspot[] hotspots;
+    @Getter private boolean turn;
 
     public Animation(final Variable condition, final Pose[] poses, final Hotspot[] hotspots, final boolean turn) {
         if (poses.length == 0) {
@@ -70,11 +71,4 @@ public class Animation {
         return poses;
     }
 
-    public Hotspot[] getHotspots() {
-        return hotspots;
-    }
-
-    public boolean isTurn() {
-        return turn;
-    }
 }

--- a/src/main/java/com/group_finity/mascot/animation/Pose.java
+++ b/src/main/java/com/group_finity/mascot/animation/Pose.java
@@ -3,6 +3,7 @@ package com.group_finity.mascot.animation;
 import com.group_finity.mascot.Mascot;
 import com.group_finity.mascot.image.ImagePair;
 import com.group_finity.mascot.image.ImagePairs;
+import lombok.Getter;
 
 import java.awt.*;
 
@@ -13,9 +14,9 @@ import java.awt.*;
 public class Pose {
     private final String image;
     private final String rightImage;
-    private final int dx;
-    private final int dy;
-    private final int duration;
+    @Getter private final int dx;
+    @Getter private final int dy;
+    @Getter private final int duration;
     private final String sound;
 
     public Pose(final String image) {
@@ -63,24 +64,12 @@ public class Pose {
         mascot.setSound(getSoundName());
     }
 
-    public int getDuration() {
-        return duration;
-    }
-
     public String getImageName() {
         return (image == null ? "" : image) + (rightImage == null ? "" : rightImage);
     }
 
     public ImagePair getImage() {
         return ImagePairs.getImagePair(getImageName());
-    }
-
-    public int getDx() {
-        return dx;
-    }
-
-    public int getDy() {
-        return dy;
     }
 
     public String getSoundName() {

--- a/src/main/java/com/group_finity/mascot/behavior/UserBehavior.java
+++ b/src/main/java/com/group_finity/mascot/behavior/UserBehavior.java
@@ -11,6 +11,8 @@ import com.group_finity.mascot.exception.CantBeAliveException;
 import com.group_finity.mascot.exception.LostGroundException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.hotspot.Hotspot;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.swing.*;
 import java.awt.*;
@@ -45,7 +47,7 @@ public class UserBehavior implements Behavior {
 
     private final Action action;
 
-    private Mascot mascot;
+    @Getter @Setter private Mascot mascot;
 
     public UserBehavior(final String name, final Action action, final Configuration configuration) {
         this.name = name;
@@ -247,14 +249,6 @@ public class UserBehavior implements Behavior {
         } catch (final VariableException e) {
             throw new CantBeAliveException(Main.getInstance().getLanguageBundle().getString("VariableEvaluationErrorMessage"), e);
         }
-    }
-
-    private void setMascot(final Mascot mascot) {
-        this.mascot = mascot;
-    }
-
-    private Mascot getMascot() {
-        return mascot;
     }
 
     protected MascotEnvironment getEnvironment() {

--- a/src/main/java/com/group_finity/mascot/config/ActionBuilder.java
+++ b/src/main/java/com/group_finity/mascot/config/ActionBuilder.java
@@ -9,6 +9,7 @@ import com.group_finity.mascot.exception.ConfigurationException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.Variable;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -23,12 +24,12 @@ import java.util.logging.Logger;
 public class ActionBuilder implements IActionBuilder {
 
     private static final Logger log = Logger.getLogger(ActionBuilder.class.getName());
-    private final String type;
-    private final String name;
-    private final String className;
-    private final Map<String, String> params = new LinkedHashMap<>();
-    private final List<AnimationBuilder> animationBuilders = new ArrayList<>();
-    private final List<IActionBuilder> actionRefs = new ArrayList<>();
+    @Getter private final String type;
+    @Getter private final String name;
+    @Getter private final String className;
+    @Getter private final Map<String, String> params = new LinkedHashMap<>();
+    @Getter private final List<AnimationBuilder> animationBuilders = new ArrayList<>();
+    @Getter private final List<IActionBuilder> actionRefs = new ArrayList<>();
     private final ResourceBundle schema;
 
     public ActionBuilder(final Configuration configuration, final Entry actionNode, final String imageSet) throws IOException {
@@ -159,30 +160,4 @@ public class ActionBuilder implements IActionBuilder {
         }
         return variables;
     }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    private String getClassName() {
-        return className;
-    }
-
-    private Map<String, String> getParams() {
-        return params;
-    }
-
-    private List<AnimationBuilder> getAnimationBuilders() {
-        return animationBuilders;
-    }
-
-    private List<IActionBuilder> getActionRefs() {
-        return actionRefs;
-    }
-
-
 }

--- a/src/main/java/com/group_finity/mascot/config/BehaviorBuilder.java
+++ b/src/main/java/com/group_finity/mascot/config/BehaviorBuilder.java
@@ -9,6 +9,7 @@ import com.group_finity.mascot.exception.ConfigurationException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.Variable;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -21,6 +22,7 @@ import java.util.logging.Logger;
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@Getter
 public class BehaviorBuilder {
 
     private static final Logger log = Logger.getLogger(BehaviorBuilder.class.getName());
@@ -141,45 +143,5 @@ public class BehaviorBuilder {
         }
 
         return true;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public int getFrequency() {
-        return frequency;
-    }
-
-    public boolean isHidden() {
-        return hidden;
-    }
-
-    public boolean isToggleable() {
-        return toggleable;
-    }
-
-    private String getActionName() {
-        return actionName;
-    }
-
-    private Map<String, String> getParams() {
-        return params;
-    }
-
-    private List<String> getConditions() {
-        return conditions;
-    }
-
-    private Configuration getConfiguration() {
-        return configuration;
-    }
-
-    public boolean isNextAdditive() {
-        return nextAdditive;
-    }
-
-    public List<BehaviorBuilder> getNextBehaviorBuilders() {
-        return nextBehaviorBuilders;
     }
 }

--- a/src/main/java/com/group_finity/mascot/config/Configuration.java
+++ b/src/main/java/com/group_finity/mascot/config/Configuration.java
@@ -10,6 +10,7 @@ import com.group_finity.mascot.exception.BehaviorInstantiationException;
 import com.group_finity.mascot.exception.ConfigurationException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.script.VariableMap;
+import lombok.Getter;
 
 import java.awt.*;
 import java.io.IOException;
@@ -26,11 +27,11 @@ import java.util.logging.Logger;
  */
 public class Configuration {
     private static final Logger log = Logger.getLogger(Configuration.class.getName());
-    private final Map<String, String> constants = new LinkedHashMap<>(2);
-    private final Map<String, ActionBuilder> actionBuilders = new LinkedHashMap<>();
-    private final Map<String, BehaviorBuilder> behaviorBuilders = new LinkedHashMap<>();
+    @Getter private final Map<String, String> constants = new LinkedHashMap<>(2);
+    @Getter private final Map<String, ActionBuilder> actionBuilders = new LinkedHashMap<>();
+    @Getter private final Map<String, BehaviorBuilder> behaviorBuilders = new LinkedHashMap<>();
     private final Map<String, String> information = new LinkedHashMap<>(8);
-    private ResourceBundle schema;
+    @Getter private ResourceBundle schema;
 
     public void load(final Entry configurationNode, final String imageSet) throws IOException, ConfigurationException {
         log.log(Level.INFO, "Reading configuration file...");
@@ -277,18 +278,6 @@ public class Configuration {
         }
     }
 
-    private Map<String, String> getConstants() {
-        return constants;
-    }
-
-    Map<String, ActionBuilder> getActionBuilders() {
-        return actionBuilders;
-    }
-
-    private Map<String, BehaviorBuilder> getBehaviorBuilders() {
-        return behaviorBuilders;
-    }
-
     public Set<String> getBehaviorNames() {
         return behaviorBuilders.keySet();
     }
@@ -299,9 +288,5 @@ public class Configuration {
 
     public String getInformation(String key) {
         return information.get(key);
-    }
-
-    public ResourceBundle getSchema() {
-        return schema;
     }
 }

--- a/src/main/java/com/group_finity/mascot/environment/Area.java
+++ b/src/main/java/com/group_finity/mascot/environment/Area.java
@@ -1,30 +1,34 @@
 package com.group_finity.mascot.environment;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.awt.*;
 
 /**
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@Getter
 public class Area {
-
+    @Setter
     private boolean visible = true;
 
-    private int left;
+    @Setter private int left;
 
-    private int top;
+    @Setter private int top;
 
-    private int right;
+    @Setter private int right;
 
-    private int bottom;
+    @Setter private int bottom;
 
-    private int dleft;
+    @Setter private int dleft;
 
-    private int dtop;
+    @Setter private int dtop;
 
-    private int dright;
+    @Setter private int dright;
 
-    private int dbottom;
+    @Setter private int dbottom;
 
     private final Wall leftBorder = new Wall(this, false);
 
@@ -33,94 +37,6 @@ public class Area {
     private final Wall rightBorder = new Wall(this, true);
 
     private final FloorCeiling bottomBorder = new FloorCeiling(this, true);
-
-    public boolean isVisible() {
-        return visible;
-    }
-
-    public void setVisible(final boolean visible) {
-        this.visible = visible;
-    }
-
-    public int getLeft() {
-        return left;
-    }
-
-    public void setLeft(final int left) {
-        this.left = left;
-    }
-
-    public int getTop() {
-        return top;
-    }
-
-    public void setTop(final int top) {
-        this.top = top;
-    }
-
-    public int getRight() {
-        return right;
-    }
-
-    public void setRight(final int right) {
-        this.right = right;
-    }
-
-    public int getBottom() {
-        return bottom;
-    }
-
-    public void setBottom(final int bottom) {
-        this.bottom = bottom;
-    }
-
-    public int getDleft() {
-        return dleft;
-    }
-
-    public void setDleft(final int dleft) {
-        this.dleft = dleft;
-    }
-
-    public int getDtop() {
-        return dtop;
-    }
-
-    public void setDtop(final int dtop) {
-        this.dtop = dtop;
-    }
-
-    public int getDright() {
-        return dright;
-    }
-
-    public void setDright(final int dright) {
-        this.dright = dright;
-    }
-
-    public int getDbottom() {
-        return dbottom;
-    }
-
-    public void setDbottom(final int dbottom) {
-        this.dbottom = dbottom;
-    }
-
-    public Wall getLeftBorder() {
-        return leftBorder;
-    }
-
-    public FloorCeiling getTopBorder() {
-        return topBorder;
-    }
-
-    public Wall getRightBorder() {
-        return rightBorder;
-    }
-
-    public FloorCeiling getBottomBorder() {
-        return bottomBorder;
-    }
 
     public int getWidth() {
         return getRight() - getLeft();
@@ -144,7 +60,6 @@ public class Area {
     }
 
     public boolean contains(final int x, final int y) {
-
         return getLeft() <= x && x <= getRight() && getTop() <= y && y <= getBottom();
     }
 

--- a/src/main/java/com/group_finity/mascot/environment/Environment.java
+++ b/src/main/java/com/group_finity/mascot/environment/Environment.java
@@ -1,5 +1,7 @@
 package com.group_finity.mascot.environment;
 
+import lombok.Getter;
+
 import java.awt.*;
 import java.util.Collection;
 import java.util.HashMap;
@@ -9,6 +11,7 @@ import java.util.Map;
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@Getter
 public abstract class Environment {
     protected abstract Area getWorkArea();
 
@@ -100,20 +103,8 @@ public abstract class Environment {
         getCursor().set(getCursorPos());
     }
 
-    public Area getScreen() {
-        return screen;
-    }
-
     public Collection<Area> getScreens() {
         return complexScreen.getAreas();
-    }
-
-    public ComplexArea getComplexScreen() {
-        return complexScreen;
-    }
-
-    public Location getCursor() {
-        return cursor;
     }
 
     public boolean isScreenTopBottom(final Point location) {

--- a/src/main/java/com/group_finity/mascot/environment/FloorCeiling.java
+++ b/src/main/java/com/group_finity/mascot/environment/FloorCeiling.java
@@ -1,29 +1,20 @@
 package com.group_finity.mascot.environment;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.awt.*;
 
 /**
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@AllArgsConstructor
+@Getter
 public class FloorCeiling implements Border {
-
     private Area area;
 
     private boolean bottom;
-
-    public FloorCeiling(final Area area, final boolean bottom) {
-        this.area = area;
-        this.bottom = bottom;
-    }
-
-    public Area getArea() {
-        return area;
-    }
-
-    public boolean isBottom() {
-        return bottom;
-    }
 
     public int getY() {
         return isBottom() ? getArea().getBottom() : getArea().getTop();

--- a/src/main/java/com/group_finity/mascot/environment/Location.java
+++ b/src/main/java/com/group_finity/mascot/environment/Location.java
@@ -1,50 +1,20 @@
 package com.group_finity.mascot.environment;
 
+import lombok.Data;
+
 import java.awt.*;
 
 /**
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@Data
 public class Location {
-
     private int x;
     private int y;
 
     private int dx;
     private int dy;
-
-    public int getX() {
-        return x;
-    }
-
-    public void setX(final int x) {
-        this.x = x;
-    }
-
-    public int getY() {
-        return y;
-    }
-
-    public void setY(final int y) {
-        this.y = y;
-    }
-
-    public int getDx() {
-        return dx;
-    }
-
-    public void setDx(final int dx) {
-        this.dx = dx;
-    }
-
-    public int getDy() {
-        return dy;
-    }
-
-    public void setDy(final int dy) {
-        this.dy = dy;
-    }
 
     public void set(final Point value) {
         setDx((getDx() + value.x - getX()) / 2);

--- a/src/main/java/com/group_finity/mascot/environment/NotOnBorder.java
+++ b/src/main/java/com/group_finity/mascot/environment/NotOnBorder.java
@@ -1,18 +1,16 @@
 package com.group_finity.mascot.environment;
 
+import lombok.NoArgsConstructor;
+
 import java.awt.*;
 
 /**
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@NoArgsConstructor
 public class NotOnBorder implements Border {
-
     public static final NotOnBorder INSTANCE = new NotOnBorder();
-
-    private NotOnBorder() {
-
-    }
 
     @Override
     public boolean isOn(final Point location) {

--- a/src/main/java/com/group_finity/mascot/environment/Wall.java
+++ b/src/main/java/com/group_finity/mascot/environment/Wall.java
@@ -1,29 +1,20 @@
 package com.group_finity.mascot.environment;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.awt.*;
 
 /**
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@AllArgsConstructor
+@Getter
 public class Wall implements Border {
-
     private Area area;
 
     private boolean right;
-
-    public Wall(final Area area, final boolean right) {
-        this.area = area;
-        this.right = right;
-    }
-
-    public Area getArea() {
-        return area;
-    }
-
-    public boolean isRight() {
-        return right;
-    }
 
     public int getX() {
         return isRight() ? getArea().getRight() : getArea().getLeft();

--- a/src/main/java/com/group_finity/mascot/generic/GenericNativeImage.java
+++ b/src/main/java/com/group_finity/mascot/generic/GenericNativeImage.java
@@ -1,6 +1,7 @@
 package com.group_finity.mascot.generic;
 
 import com.group_finity.mascot.image.NativeImage;
+import lombok.Getter;
 
 import javax.swing.*;
 import java.awt.image.BufferedImage;
@@ -21,7 +22,7 @@ class GenericNativeImage implements NativeImage {
      */
     private final BufferedImage managedImage;
 
-    private final Icon icon;
+    @Getter private final Icon icon;
 
     public GenericNativeImage(final BufferedImage image) {
         managedImage = image;
@@ -30,9 +31,5 @@ class GenericNativeImage implements NativeImage {
 
     BufferedImage getManagedImage() {
         return managedImage;
-    }
-
-    public Icon getIcon() {
-        return icon;
     }
 }

--- a/src/main/java/com/group_finity/mascot/generic/GenericTranslucentWindow.java
+++ b/src/main/java/com/group_finity/mascot/generic/GenericTranslucentWindow.java
@@ -4,6 +4,7 @@ import com.group_finity.mascot.Mascot;
 import com.group_finity.mascot.image.NativeImage;
 import com.group_finity.mascot.image.TranslucentWindow;
 import com.sun.jna.platform.WindowUtils;
+import lombok.Getter;
 
 import javax.swing.*;
 import java.awt.*;
@@ -12,6 +13,7 @@ import java.awt.*;
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@Getter
 class GenericTranslucentWindow extends JWindow implements TranslucentWindow {
 
     private static final long serialVersionUID = 1L;
@@ -75,10 +77,6 @@ class GenericTranslucentWindow extends JWindow implements TranslucentWindow {
         }
     }
 
-    public float getAlpha() {
-        return alpha;
-    }
-
     public void setAlpha(final float alpha) {
         WindowUtils.setWindowAlpha(this, alpha);
         this.alpha = alpha;
@@ -92,10 +90,6 @@ class GenericTranslucentWindow extends JWindow implements TranslucentWindow {
     @Override
     public String toString() {
         return "LayeredWindow[hashCode=" + hashCode() + ",bounds=" + getBounds() + "]";
-    }
-
-    public GenericNativeImage getImage() {
-        return image;
     }
 
     @Override

--- a/src/main/java/com/group_finity/mascot/hotspot/Hotspot.java
+++ b/src/main/java/com/group_finity/mascot/hotspot/Hotspot.java
@@ -1,6 +1,8 @@
 package com.group_finity.mascot.hotspot;
 
 import com.group_finity.mascot.Mascot;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.awt.*;
 
@@ -13,15 +15,11 @@ import java.awt.*;
  * @author Kilkakon
  * @since 1.0.19
  */
+@AllArgsConstructor
+@Getter
 public class Hotspot {
     private final String behaviour;
-
     private final Shape shape;
-
-    public Hotspot(String behaviour, Shape shape) {
-        this.behaviour = behaviour;
-        this.shape = shape;
-    }
 
     public boolean contains(Mascot mascot, Point point) {
         // flip if facing right
@@ -30,13 +28,5 @@ public class Hotspot {
         }
 
         return shape.contains(point);
-    }
-
-    public String getBehaviour() {
-        return behaviour;
-    }
-
-    public Shape getShape() {
-        return shape;
     }
 }

--- a/src/main/java/com/group_finity/mascot/image/ImagePair.java
+++ b/src/main/java/com/group_finity/mascot/image/ImagePair.java
@@ -1,5 +1,7 @@
 package com.group_finity.mascot.image;
 
+import lombok.Getter;
+
 /**
  * A pair of left and right mascot images.
  * <p>
@@ -8,8 +10,8 @@ package com.group_finity.mascot.image;
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@Getter
 public class ImagePair {
-
     /**
      * Image facing left.
      */
@@ -40,13 +42,5 @@ public class ImagePair {
      */
     public MascotImage getImage(final boolean lookRight) {
         return lookRight ? getRightImage() : getLeftImage();
-    }
-
-    private MascotImage getLeftImage() {
-        return leftImage;
-    }
-
-    private MascotImage getRightImage() {
-        return rightImage;
     }
 }

--- a/src/main/java/com/group_finity/mascot/image/MascotImage.java
+++ b/src/main/java/com/group_finity/mascot/image/MascotImage.java
@@ -1,6 +1,8 @@
 package com.group_finity.mascot.image;
 
 import com.group_finity.mascot.NativeFactory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -9,34 +11,16 @@ import java.awt.image.BufferedImage;
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
  */
+@AllArgsConstructor
+@Getter
 public class MascotImage {
-
     private final NativeImage image;
 
     private final Point center;
 
     private final Dimension size;
 
-    public MascotImage(final NativeImage image, final Point center, final Dimension size) {
-        this.image = image;
-        this.center = center;
-        this.size = size;
-    }
-
     public MascotImage(final BufferedImage image, final Point center) {
         this(NativeFactory.getInstance().newNativeImage(image), center, new Dimension(image.getWidth(), image.getHeight()));
     }
-
-    public NativeImage getImage() {
-        return image;
-    }
-
-    public Point getCenter() {
-        return center;
-    }
-
-    public Dimension getSize() {
-        return size;
-    }
-
 }

--- a/src/main/java/com/group_finity/mascot/menu/MenuScroller.java
+++ b/src/main/java/com/group_finity/mascot/menu/MenuScroller.java
@@ -1,6 +1,8 @@
 package com.group_finity.mascot.menu;
 
 import com.group_finity.mascot.Main;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.swing.*;
 import javax.swing.event.*;
@@ -34,10 +36,14 @@ public class MenuScroller
     private MenuScrollerItem downItem;
     private final MenuScrollerPopupMenuListener menuScrollerPopupMenuListener = new MenuScrollerPopupMenuListener();
     private final MenuScrollerMenuKeyListener menuScrollerMenuKeyListener = new MenuScrollerMenuKeyListener();
-    private int scrollCount;
-    private int interval;
-    private int topFixedCount;
-    private int bottomFixedCount;
+    /** The number of items in the scrolling portion of the menu. */
+    @Getter private int scrollCount;
+    /** The scroll interval in milliseconds. */
+    @Getter private int interval;
+    /** The number of items fixed at the top of the menu or popup menu. */
+    @Getter private int topFixedCount;
+    /** The number of items fixed at the bottom of the menu or popup menu. */
+    @Getter @Setter private int bottomFixedCount;
     private int firstIndex = 0;
     private int keepVisibleIndex = -1;
 
@@ -373,15 +379,6 @@ public class MenuScroller
     }
 
     /**
-     * Return the scroll interval in milliseconds.
-     *
-     * @return the scroll interval in milliseconds
-     */
-    public int getInterval() {
-        return interval;
-    }
-
-    /**
      * Set the scroll interval in milliseconds.
      *
      * @param interval the scroll interval in milliseconds
@@ -394,15 +391,6 @@ public class MenuScroller
         upItem.setInterval(interval);
         downItem.setInterval(interval);
         this.interval = interval;
-    }
-
-    /**
-     * Return the number of items in the scrolling portion of the menu.
-     *
-     * @return the number of items to display at a time
-     */
-    public int getScrollCount() {
-        return scrollCount;
     }
 
     /**
@@ -420,15 +408,6 @@ public class MenuScroller
     }
 
     /**
-     * Return the number of items fixed at the top of the menu or popup menu.
-     *
-     * @return the number of items
-     */
-    public int getTopFixedCount() {
-        return topFixedCount;
-    }
-
-    /**
      * Set the number of items to fix at the top of the menu or popup menu.
      *
      * @param topFixedCount the number of items
@@ -440,25 +419,6 @@ public class MenuScroller
             firstIndex += topFixedCount - this.topFixedCount;
         }
         this.topFixedCount = topFixedCount;
-    }
-
-    /**
-     * Return the number of items fixed at the bottom of the menu or popup
-     * menu.
-     *
-     * @return the number of items
-     */
-    public int getBottomFixedCount() {
-        return bottomFixedCount;
-    }
-
-    /**
-     * Set the number of items to fix at the bottom of the menu or popup menu.
-     *
-     * @param bottomFixedCount the number of items
-     */
-    public void setBottomFixedCount(int bottomFixedCount) {
-        this.bottomFixedCount = bottomFixedCount;
     }
 
     /**

--- a/src/main/java/com/group_finity/mascot/script/Script.java
+++ b/src/main/java/com/group_finity/mascot/script/Script.java
@@ -2,6 +2,8 @@ package com.group_finity.mascot.script;
 
 import com.group_finity.mascot.Main;
 import com.group_finity.mascot.exception.VariableException;
+import lombok.Getter;
+import lombok.Setter;
 import org.openjdk.nashorn.api.scripting.NashornScriptEngine;
 import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 
@@ -13,16 +15,15 @@ import javax.script.ScriptException;
  * @author Shimeji-ee Group
  */
 public class Script extends Variable {
-
     private static final NashornScriptEngine ENGINE = (NashornScriptEngine) new NashornScriptEngineFactory().getScriptEngine(new ScriptFilter());
 
-    private final String source;
+    @Getter private final String source;
 
-    private final boolean clearAtInitFrame;
+    @Getter private final boolean clearAtInitFrame;
 
-    private final CompiledScript compiled;
+    @Getter private final CompiledScript compiled;
 
-    private Object value;
+    @Getter @Setter private Object value;
 
     public Script(final String source, final boolean clearAtInitFrame) throws VariableException {
         this.source = source;
@@ -65,25 +66,5 @@ public class Script extends Variable {
         }
 
         return getValue();
-    }
-
-    private void setValue(final Object value) {
-        this.value = value;
-    }
-
-    private Object getValue() {
-        return value;
-    }
-
-    private boolean isClearAtInitFrame() {
-        return clearAtInitFrame;
-    }
-
-    private CompiledScript getCompiled() {
-        return compiled;
-    }
-
-    private String getSource() {
-        return source;
     }
 }

--- a/src/main/java/com/group_finity/mascot/script/VariableMap.java
+++ b/src/main/java/com/group_finity/mascot/script/VariableMap.java
@@ -2,6 +2,7 @@ package com.group_finity.mascot.script;
 
 import com.group_finity.mascot.Main;
 import com.group_finity.mascot.exception.VariableException;
+import lombok.Getter;
 
 import javax.script.Bindings;
 import java.util.*;
@@ -11,12 +12,7 @@ import java.util.*;
  * @author Shimeji-ee Group
  */
 public class VariableMap extends AbstractMap<String, Object> implements Bindings {
-
-    private final Map<String, Variable> rawMap = new LinkedHashMap<>();
-
-    public Map<String, Variable> getRawMap() {
-        return rawMap;
-    }
+    @Getter private final Map<String, Variable> rawMap = new LinkedHashMap<>();
 
     public void init() {
         for (final Variable o : getRawMap().values()) {


### PR DESCRIPTION
This requires that Lombok be added as a dependency, as it has been in #4.

I made an initial attempt at reducing the project's boilerplate code with Lombok. For the most part, I replaced getters and setters with `@Getter`, `@Setter`, and the occasional `@Data` annotation. There are a few instances of `@AllArgsConstructor` and `@NoArgsConstructor` as well.

The `theme.properties` file seems to have been regenerated, or rearranged, by running the program. The values haven't changed, so it seemed fine to commit.