### PR TITLE
Fix issue where `Mascot` debugging bounding box was drawn incorrectly

### DIFF
--- a/src/main/java/com/group_finity/mascot/Mascot.java
+++ b/src/main/java/com/group_finity/mascot/Mascot.java
@@ -206,7 +206,7 @@ public class Mascot {
                     // Draw bounds
                     g.setColor(Color.RED);
                     Rectangle bounds = getBounds();
-                    g.drawRect(bounds.x, bounds.y, bounds.width, bounds.height);
+                    g.drawRect(bounds.x, bounds.y, bounds.width - 1, bounds.height - 1);
 
                     // Draw image anchor
                     g.setColor(Color.GREEN);


### PR DESCRIPTION
The bounding box rect didn't take into consideration the line width of the drawn box, so the right and bottom sides were drawn "off-screen".