### PR TITLE
Refactor image scaling code and add support for bilinear filtering.

### DIFF
--- a/conf/language.properties
+++ b/conf/language.properties
@@ -157,6 +157,7 @@ General=General
 WindowMode=Window Mode
 FilterOptions=Filter
 NearestNeighbour=Nearest Neighbour (No filter)
+BilinearFilter=Bilinear Filter
 BicubicFilter=Bicubic Filter
 WindowedModeEnabled=Enable Windowed Mode
 Dimensions=Dimensions

--- a/conf/language_en.properties
+++ b/conf/language_en.properties
@@ -157,6 +157,7 @@ General=General
 WindowMode=Window Mode
 FilterOptions=Filter
 NearestNeighbour=Nearest Neighbour (No filter)
+BilinearFilter=Bilinear Filter
 BicubicFilter=Bicubic Filter
 WindowedModeEnabled=Enable Windowed Mode
 Dimensions=Dimensions

--- a/src/main/java/com/group_finity/mascot/SettingsWindow.java
+++ b/src/main/java/com/group_finity/mascot/SettingsWindow.java
@@ -5,6 +5,8 @@
  */
 package com.group_finity.mascot;
 
+import com.group_finity.mascot.image.ImageScaler;
+
 import javax.swing.*;
 import javax.swing.border.BevelBorder;
 import javax.swing.border.SoftBevelBorder;

--- a/src/main/java/com/group_finity/mascot/config/AnimationBuilder.java
+++ b/src/main/java/com/group_finity/mascot/config/AnimationBuilder.java
@@ -7,7 +7,7 @@ import com.group_finity.mascot.exception.AnimationInstantiationException;
 import com.group_finity.mascot.exception.VariableException;
 import com.group_finity.mascot.hotspot.Hotspot;
 import com.group_finity.mascot.image.ImagePairLoader;
-import com.group_finity.mascot.image.ImagePairLoader.Filter;
+import com.group_finity.mascot.image.ImageScaler;
 import com.group_finity.mascot.script.Variable;
 import com.group_finity.mascot.sound.SoundLoader;
 
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 /**
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
+ * @author Valkryst
  */
 public class AnimationBuilder {
     private static final Logger log = Logger.getLogger(AnimationBuilder.class.getName());
@@ -72,20 +73,14 @@ public class AnimationBuilder {
         final double opacity = Double.parseDouble(Main.getInstance().getProperties().getProperty("Opacity", "1.0"));
         final double scaling = Double.parseDouble(Main.getInstance().getProperties().getProperty("Scaling", "1.0"));
 
-        String filterText = Main.getInstance().getProperties().getProperty("Filter", "false");
-        Filter filter = Filter.NEAREST_NEIGHBOUR;
-        if (filterText.equalsIgnoreCase("true") || filterText.equalsIgnoreCase("hqx")) {
-            filter = ImagePairLoader.Filter.HQX;
-        } else if (filterText.equalsIgnoreCase("bicubic")) {
-            filter = ImagePairLoader.Filter.BICUBIC;
-        }
+        final ImageScaler imageScaler = ImageScaler.valueOf(Main.getInstance().getProperties().getProperty("Filter", ImageScaler.NEAREST_NEIGHBOUR.name()));
 
         if (imageText != null) {
             try {
                 final String[] anchorCoordinates = anchorText.split(",");
                 final Point anchor = new Point(Integer.parseInt(anchorCoordinates[0]), Integer.parseInt(anchorCoordinates[1]));
 
-                ImagePairLoader.load(imageText, imageRightText, anchor, scaling, filter, opacity);
+                ImagePairLoader.load(imageText, imageRightText, anchor, scaling, imageScaler, opacity);
             } catch (IOException | NumberFormatException e) {
                 String error = imageText;
                 if (imageRightText != null) {

--- a/src/main/java/com/group_finity/mascot/image/ImagePairLoader.java
+++ b/src/main/java/com/group_finity/mascot/image/ImagePairLoader.java
@@ -1,9 +1,6 @@
 package com.group_finity.mascot.image;
 
 import com.group_finity.mascot.Main;
-import hqx.Hqx_2x;
-import hqx.Hqx_3x;
-import hqx.Hqx_4x;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
@@ -15,14 +12,9 @@ import java.io.IOException;
  *
  * @author Yuki Yamada of <a href="http://www.group-finity.com/Shimeji/">Group Finity</a>
  * @author Shimeji-ee Group
+ * @author Valkryst
  */
 public class ImagePairLoader {
-    public enum Filter {
-        NEAREST_NEIGHBOUR,
-        HQX,
-        BICUBIC
-    }
-
     /**
      * Loads an image pair.
      *
@@ -30,20 +22,27 @@ public class ImagePairLoader {
      * @param rightName file name of right-facing image to load
      * @param center image center coordinate
      * @param scaling the scale factor of the image
-     * @param filter the type of filter to use to generate the image
+     * @param imageScaler {@link ImageScaler} to use when rescaling the image.
      */
-    public static void load(final String name, final String rightName, final Point center, final double scaling, final Filter filter, final double opacity) throws IOException {
+    public static void load(
+        final String name,
+        final String rightName,
+        final Point center,
+        final double scaling,
+        final ImageScaler imageScaler,
+        final double opacity
+    ) throws IOException {
         String key = name + (rightName == null ? "" : rightName);
         if (ImagePairs.contains(key)) {
             return;
         }
 
-        final BufferedImage leftImage = scale(premultiply(ImageIO.read(Main.IMAGE_DIRECTORY.resolve(name).toFile()), opacity), scaling, filter);
+        final BufferedImage leftImage = imageScaler.scale(premultiply(ImageIO.read(Main.IMAGE_DIRECTORY.resolve(name).toFile()), opacity), scaling);
         final BufferedImage rightImage;
         if (rightName == null) {
             rightImage = flip(leftImage);
         } else {
-            rightImage = scale(premultiply(ImageIO.read(Main.IMAGE_DIRECTORY.resolve(rightName).toFile()), opacity), scaling, filter);
+            rightImage = imageScaler.scale(premultiply(ImageIO.read(Main.IMAGE_DIRECTORY.resolve(rightName).toFile()), opacity), scaling);
         }
 
         ImagePair ip = new ImagePair(new MascotImage(leftImage, new Point((int) Math.round(center.x * scaling), (int) Math.round(center.y * scaling))),
@@ -89,82 +88,5 @@ public class ImagePairLoader {
         }
 
         return returnImage;
-    }
-
-    private static BufferedImage scale(final BufferedImage source, final double scaling, Filter filter) {
-        int width = source.getWidth();
-        int height = source.getHeight();
-        BufferedImage workingImage = null;
-
-        // apply hqx if applicable
-        double effectiveScaling = scaling;
-        if (filter == Filter.HQX && scaling > 1) {
-            int[] buffer;
-            int[] rbgValues = source.getRGB(0, 0, width, height, null, 0, width);
-
-            if (scaling == 4 || scaling == 8) {
-                width *= 4;
-                height *= 4;
-                buffer = new int[width * height];
-                Hqx_4x.hq4x_32_rb(rbgValues, buffer, width / 4, height / 4);
-                rbgValues = buffer;
-                effectiveScaling = scaling > 4 ? 2 : 1;
-            } else if (scaling == 3 || scaling == 6) {
-                width *= 3;
-                height *= 3;
-                buffer = new int[width * height];
-                Hqx_3x.hq3x_32_rb(rbgValues, buffer, width / 3, height / 3);
-                rbgValues = buffer;
-                effectiveScaling = scaling > 4 ? 2 : 1;
-            } else if (scaling == 2) {
-                width *= 2;
-                height *= 2;
-                buffer = new int[width * height];
-                Hqx_2x.hq2x_32_rb(rbgValues, buffer, width / 2, height / 2);
-                rbgValues = buffer;
-                effectiveScaling = 1;
-            } else {
-                filter = Filter.NEAREST_NEIGHBOUR;
-            }
-
-            // if hqx is still on then apply the changes
-            if (filter == Filter.HQX) {
-                workingImage = new BufferedImage((int) Math.round(width * effectiveScaling), (int) Math.round(height * effectiveScaling), BufferedImage.TYPE_INT_ARGB_PRE);
-                int srcColIndex = 0;
-                int srcRowIndex = 0;
-
-                for (int y = 0; y < workingImage.getHeight(); y++) {
-                    for (int x = 0; x < workingImage.getWidth(); x++) {
-                        workingImage.setRGB(x, y, rbgValues[srcColIndex / (int) effectiveScaling]);
-                        srcColIndex++;
-                    }
-
-                    // resets the srcColIndex to re-use the same indexes and stretch horizontally
-                    srcRowIndex++;
-                    if (srcRowIndex == effectiveScaling) {
-                        srcRowIndex = 0;
-                    } else {
-                        srcColIndex -= workingImage.getWidth();
-                    }
-                }
-            }
-        }
-
-        width = (int) Math.round(width * effectiveScaling);
-        height = (int) Math.round(height * effectiveScaling);
-
-        final BufferedImage copy = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB_PRE);
-
-        Graphics2D g2d = copy.createGraphics();
-        Object renderHint = filter == Filter.BICUBIC
-                ? RenderingHints.VALUE_INTERPOLATION_BICUBIC
-                : RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR;
-
-        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, renderHint);
-        g2d.drawImage(workingImage != null ? workingImage : source, 0, 0, width, height, null);
-
-        g2d.dispose();
-
-        return copy;
     }
 }

--- a/src/main/java/com/group_finity/mascot/image/ImageScaler.java
+++ b/src/main/java/com/group_finity/mascot/image/ImageScaler.java
@@ -81,9 +81,8 @@ public enum ImageScaler {
     private BufferedImage scaleHQX(final BufferedImage source, double scaleFactor) {
         int scaledWidth = source.getWidth();
         int scaledHeight = source.getHeight();
-        BufferedImage destination;
+        final BufferedImage destination;
 
-        // apply hqx if applicable
         int[] buffer;
         int[] rbgValues = source.getRGB(0, 0, scaledWidth, scaledHeight, null, 0, scaledWidth);
 

--- a/src/main/java/com/group_finity/mascot/image/ImageScaler.java
+++ b/src/main/java/com/group_finity/mascot/image/ImageScaler.java
@@ -1,0 +1,156 @@
+package com.group_finity.mascot.image;
+
+import hqx.Hqx_2x;
+import hqx.Hqx_3x;
+import hqx.Hqx_4x;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.Map;
+
+/**
+ * Facilitates scaling of {@link BufferedImage} objects using various algorithms.
+ *
+ * @author Valkryst
+ */
+public enum ImageScaler {
+    NEAREST_NEIGHBOUR,
+    BILINEAR,
+    BICUBIC,
+    HQX;
+
+    /**
+     * Scales a {@link BufferedImage} using this image scaling algorithm.
+     *
+     * @param source {@link BufferedImage} to scale.
+     * @param scaleFactor Amount to scale the image by.
+     * @return The rescaled {@link BufferedImage}.
+     */
+    public BufferedImage scale(final BufferedImage source, final double scaleFactor) {
+        // If we're not scaling the image, just return a deep copy of it.
+        // todo Determine if the rest of the codebase needs a deep copy, or if we can reuse the original.
+        if (scaleFactor == 1.0) {
+            final BufferedImage destination = new BufferedImage(source.getWidth(), source.getHeight(), source.getType());
+            destination.copyData(source.getRaster());
+            return destination;
+        }
+
+        // The HQX algorithm can only be used for upscaling.
+        if (this == HQX && scaleFactor > 1.0) {
+            return this.scaleHQX(source, scaleFactor);
+        }
+
+        final int scaledWidth = (int) Math.round(source.getWidth() * scaleFactor);
+        final int scaledHeight = (int) Math.round(source.getHeight() * scaleFactor);
+
+        final BufferedImage destination = new BufferedImage(scaledWidth, scaledHeight, BufferedImage.TYPE_INT_ARGB_PRE);
+        final Graphics2D graphics2D = destination.createGraphics();
+        this.setRenderingHints(graphics2D);
+
+        switch (this) {
+            case NEAREST_NEIGHBOUR: {
+                graphics2D.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+                break;
+            }
+            case BILINEAR: {
+                graphics2D.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+                break;
+            }
+            case BICUBIC: {
+                graphics2D.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+                break;
+            }
+            default: {
+                throw new UnsupportedOperationException("No implementation has been provided for the " + this + " filter.");
+            }
+        }
+
+        graphics2D.drawImage(source, 0, 0, scaledWidth, scaledHeight, null);
+        graphics2D.dispose();
+
+        return destination;
+    }
+
+    /**
+     * Scales a {@link BufferedImage} using the HQX algorithm.
+     *
+     * @param source {@link BufferedImage} to scale.
+     * @param scaleFactor Amount to scale the image by.
+     * @return The rescaled {@link BufferedImage}.
+     */
+    private BufferedImage scaleHQX(final BufferedImage source, double scaleFactor) {
+        int scaledWidth = source.getWidth();
+        int scaledHeight = source.getHeight();
+        BufferedImage destination;
+
+        // apply hqx if applicable
+        int[] buffer;
+        int[] rbgValues = source.getRGB(0, 0, scaledWidth, scaledHeight, null, 0, scaledWidth);
+
+        if (scaleFactor == 4 || scaleFactor == 8) {
+            scaledWidth *= 4;
+            scaledHeight *= 4;
+            buffer = new int[scaledWidth * scaledHeight];
+            Hqx_4x.hq4x_32_rb(rbgValues, buffer, scaledWidth / 4, scaledHeight / 4);
+            rbgValues = buffer;
+            scaleFactor = scaleFactor > 4 ? 2 : 1;
+        } else if (scaleFactor == 3 || scaleFactor == 6) {
+            scaledWidth *= 3;
+            scaledHeight *= 3;
+            buffer = new int[scaledWidth * scaledHeight];
+            Hqx_3x.hq3x_32_rb(rbgValues, buffer, scaledWidth / 3, scaledHeight / 3);
+            rbgValues = buffer;
+            scaleFactor = scaleFactor > 4 ? 2 : 1;
+        } else if (scaleFactor == 2) {
+            scaledWidth *= 2;
+            scaledHeight *= 2;
+            buffer = new int[scaledWidth * scaledHeight];
+            Hqx_2x.hq2x_32_rb(rbgValues, buffer, scaledWidth / 2, scaledHeight / 2);
+            rbgValues = buffer;
+            scaleFactor = 1;
+        } else {
+            throw new UnsupportedOperationException("The HQX algorithm cannot be used with a scaleFactor of " + scaleFactor + ".");
+        }
+
+        destination = new BufferedImage((int) Math.round(scaledWidth * scaleFactor), (int) Math.round(scaledHeight * scaleFactor), BufferedImage.TYPE_INT_ARGB_PRE);
+        int srcColIndex = 0;
+        int srcRowIndex = 0;
+
+        for (int y = 0; y < destination.getHeight(); y++) {
+            for (int x = 0; x < destination.getWidth(); x++) {
+                destination.setRGB(x, y, rbgValues[srcColIndex / (int) scaleFactor]);
+                srcColIndex++;
+            }
+
+            // resets the srcColIndex to re-use the same indexes and stretch horizontally
+            srcRowIndex++;
+            if (srcRowIndex == scaleFactor) {
+                srcRowIndex = 0;
+            } else {
+                srcColIndex -= destination.getWidth();
+            }
+        }
+
+        return destination;
+    }
+
+    /**
+     * Applies a set of {@link RenderingHints}, which have been deemed to be of high quality, to a {@link Graphics}
+     * context.
+     *
+     * @param graphics2D {@link Graphics2D} context to apply the {@link RenderingHints} to.
+     */
+    private void setRenderingHints(final Graphics2D graphics2D) {
+        // Automatically detect the best text rendering settings and apply them.
+        final var desktopHints = (Map<?, ?>) Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
+        if (desktopHints != null) {
+            graphics2D.setRenderingHints(desktopHints);
+        }
+
+        graphics2D.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+        graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        graphics2D.setRenderingHint(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
+        graphics2D.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        graphics2D.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+    }
+}


### PR DESCRIPTION
This started-off as a PR to add the missing `Bilinear` option to the set of image scaling algorithms, but I ended up moving all of the scaling logic into a dedicated class while also cleaning it up a tad.

After merging this PR, we should open a new issue to add translations for the `BilinearFilter` property in the language `*.properties` files. Machine translations would likely be fine for now.